### PR TITLE
feat: export metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "prettier": "@snapshot-labs/prettier-config",
   "dependencies": {
     "@ethersproject/wallet": "^5.7.0",
+    "@snapshot-labs/snapshot-metrics": "^1.0.0",
     "@snapshot-labs/snapshot-sentry": "^1.1.0",
     "bluebird": "^3.7.2",
     "connection-string": "^4.3.6",

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -1,0 +1,33 @@
+import init, { client } from '@snapshot-labs/snapshot-metrics';
+import db from './mysql';
+import type { Express } from 'express';
+
+export default function initMetrics(app: Express) {
+  init(app, { whitelistedPath: [/^\/$/] });
+}
+
+new client.Gauge({
+  name: 'subscribers_per_status_count',
+  help: 'Number of subscribers per status',
+  labelNames: ['status'],
+  async collect() {
+    [
+      ['active', '`key` IS NOT NULL'],
+      ['pending', '`key` IS NULL']
+    ].forEach(async function callback(this: any, data: any) {
+      this.set(
+        { status: data[0] },
+        (await db.queryAsync(`SELECT count(*) as count FROM \`keys\` WHERE ${data[1]}`))[0]
+          .count as any
+      );
+    }, this);
+  }
+});
+
+new client.Gauge({
+  name: 'total_api_requests_count',
+  help: 'Total number of API requests',
+  async collect() {
+    this.set((await db.queryAsync(`SELECT SUM(total) as count FROM reqs`))[0].count as any);
+  }
+});

--- a/src/helpers/metrics.ts
+++ b/src/helpers/metrics.ts
@@ -6,21 +6,28 @@ export default function initMetrics(app: Express) {
   init(app, { whitelistedPath: [/^\/$/] });
 }
 
+async function collectSubscriberCounts() {
+  const subscriberCounts = await Promise.all([
+    db.queryAsync('SELECT count(*) as count FROM `keys` WHERE `key` IS NOT NULL'),
+    db.queryAsync('SELECT count(*) as count FROM `keys` WHERE `key` IS NULL')
+  ]);
+
+  return [
+    { status: 'active', count: subscriberCounts[0][0].count },
+    { status: 'pending', count: subscriberCounts[1][0].count }
+  ];
+}
+
 new client.Gauge({
-  name: 'subscribers_per_status_count',
-  help: 'Number of subscribers per status',
+  name: 'snapshot_subscriber_counts',
+  help: 'Number of Snapshot subscribers by status',
   labelNames: ['status'],
   async collect() {
-    [
-      ['active', '`key` IS NOT NULL'],
-      ['pending', '`key` IS NULL']
-    ].forEach(async function callback(this: any, data: any) {
-      this.set(
-        { status: data[0] },
-        (await db.queryAsync(`SELECT count(*) as count FROM \`keys\` WHERE ${data[1]}`))[0]
-          .count as any
-      );
-    }, this);
+    const subscriberCounts = await collectSubscriberCounts();
+
+    subscriberCounts.forEach(({ status, count }) => {
+      this.set({ status }, count);
+    });
   }
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,13 @@ import cors from 'cors';
 import rpc from './rpc';
 import { rpcError } from './helpers/utils';
 import { initLogger, fallbackLogger } from '@snapshot-labs/snapshot-sentry';
+import initMetrics from './helpers/metrics';
 
 const app = express();
 const PORT = process.env.PORT || 3007;
 
 initLogger(app);
+initMetrics(app);
 
 app.use(express.json({ limit: '4mb' }));
 app.use(express.urlencoded({ limit: '4mb', extended: false }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1037,6 +1037,14 @@
   resolved "https://registry.yarnpkg.com/@snapshot-labs/prettier-config/-/prettier-config-0.1.0-beta.7.tgz#c8e07e7e9baabee245020a72ac05835b65139823"
   integrity sha512-k/FUf4VWhwLFUmKuWs2mNvmPe691hqhvCJuujD4TfbIivWysmL1TqthwfdQUrQEAQUqVQ2ZKEiGkbufp5J27eQ==
 
+"@snapshot-labs/snapshot-metrics@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot-metrics/-/snapshot-metrics-1.0.0.tgz#1f88a6aacc81f639f7059c153b53c550934cd3b3"
+  integrity sha512-6T8a2NX6Qo6zVAoNIWV8eSJCukCynI/HCLp37VZTzX8jwU/ahGsiDTQC3I/MDus+LDB+8pI5nju33NwM8Q7n2g==
+  dependencies:
+    express-prom-bundle "^6.6.0"
+    prom-client "^14.2.0"
+
 "@snapshot-labs/snapshot-sentry@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@snapshot-labs/snapshot-sentry/-/snapshot-sentry-1.1.0.tgz#b357d4789ffd287f90fb70e7f0b207b47627cf24"
@@ -1529,6 +1537,11 @@ binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+bintrees@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/bintrees/-/bintrees-1.0.2.tgz#49f896d6e858a4a499df85c38fb399b9aff840f8"
+  integrity sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==
 
 bluebird@3.7.2, bluebird@^3.7.2:
   version "3.7.2"
@@ -2206,6 +2219,14 @@ expect@^29.6.2:
     jest-matcher-utils "^29.6.2"
     jest-message-util "^29.6.2"
     jest-util "^29.6.2"
+
+express-prom-bundle@^6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/express-prom-bundle/-/express-prom-bundle-6.6.0.tgz#9c33c1bd1478d70e3961a53aed2d17f15ef821ca"
+  integrity sha512-tZh2P2p5a8/yxQ5VbRav011Poa4R0mHqdFwn9Swe/obXDe5F0jY9wtRAfNYnqk4LXY7akyvR/nrvAHxQPWUjsQ==
+  dependencies:
+    on-finished "^2.3.0"
+    url-value-parser "^2.0.0"
 
 express@^4.18.2:
   version "4.18.2"
@@ -3506,7 +3527,7 @@ object-inspect@^1.9.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.3.tgz#ba62dffd67ee256c8c086dfae69e016cd1f198b9"
   integrity sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==
 
-on-finished@2.4.1:
+on-finished@2.4.1, on-finished@^2.3.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
   integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
@@ -3692,6 +3713,13 @@ process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
+prom-client@^14.2.0:
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-14.2.0.tgz#ca94504e64156f6506574c25fb1c34df7812cf11"
+  integrity sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==
+  dependencies:
+    tdigest "^0.1.1"
 
 prompts@^2.0.1:
   version "2.4.2"
@@ -4125,6 +4153,13 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+tdigest@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/tdigest/-/tdigest-0.1.2.tgz#96c64bac4ff10746b910b0e23b515794e12faced"
+  integrity sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==
+  dependencies:
+    bintrees "1.0.2"
+
 test-exclude@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-6.0.0.tgz#04a8698661d805ea6fa293b6cb9e63ac044ef15e"
@@ -4282,6 +4317,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+url-value-parser@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/url-value-parser/-/url-value-parser-2.2.0.tgz#f38ae8cd24604ec69bc219d66929ddbbd93a2b32"
+  integrity sha512-yIQdxJpgkPamPPAPuGdS7Q548rLhny42tg8d4vyTNzFqvOnwqrgHXvgehT09U7fwrzxi3RxCiXjoNUNnNOlQ8A==
 
 util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Export metrics

To test:
- Go to `localhost:3007/metrics`

This expose the express/node default metrics, as well as some custom metrics (`subscribers_per_status_count` and `total_api_requests_count`)