### PR TITLE
Add limits, monthly_counts and reset time to get_keys method

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
-DATABASE_URL=mysql://root:default_password@localhost:3306/keycard
+DATABASE_URL=mysql://root:default_password@mysql:3306/keycard
 SECRET=
+# Sentry (optional)
 SENTRY_DSN=

--- a/src/config.json
+++ b/src/config.json
@@ -2,6 +2,9 @@
   "limits": {
     "snapshot-hub": {
       "monthly": 2e6
+    },
+    "score-api": {
+      "monthly": 2e6
     }
   }
 }

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -73,8 +73,6 @@ export const logReq = async (key: string, app: string) => {
 
     if (!keyData?.key) return { error: 'Key does not exist', code: 401 };
     if (!keyData?.active) return { error: 'Key is not active', code: 401 };
-    if (keyData?.month_total >= limits[app].monthly)
-      return { error: 'Key is restricted for this month', code: 429 };
 
     const success: boolean = await updateTotal(keyData.key, app);
     return { success };
@@ -88,12 +86,23 @@ export const getKeys = async (app: string) => {
   try {
     if (!apps.includes(app)) return { error: 'App is not allowed', code: 401 };
     const activeKeys = await getActiveKeys(app);
+    // Reset timestamp is the first day of the next month
+    const resetTimestamp = (
+      new Date(new Date().getFullYear(), new Date().getMonth() + 1, 1).getTime() / 1e3
+    ).toFixed(0);
     const result = {
       [app]: {
+        // TODO: `active` and `restricted_monthly` will be deprecated
         active: activeKeys.map((key: any) => key.key),
         restricted_monthly: activeKeys
           .filter((key: any) => key.month_total >= limits[app].monthly)
-          .map((key: any) => key.key)
+          .map((key: any) => key.key),
+        monthly_counts: activeKeys.reduce((obj, { key, month_total }) => {
+          obj[key] = month_total ?? 0;
+          return obj;
+        }, {}),
+        limits: limits[app],
+        reset: resetTimestamp
       }
     };
     return result;

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -88,7 +88,7 @@ export const getKeys = async (app: string) => {
     const activeKeys = await getActiveKeys(app);
     // Reset timestamp is the first day of the next month
     const resetTimestamp = (
-      new Date(new Date().getFullYear(), new Date().getMonth() + 1, 1).getTime() / 1e3
+      Date.UTC(new Date().getFullYear(), new Date().getMonth() + 1, 1) / 1e3
     ).toFixed(0);
     const result = {
       [app]: {

--- a/test/e2e/log_key.test.ts
+++ b/test/e2e/log_key.test.ts
@@ -7,10 +7,6 @@ describe('logKey', () => {
     it.todo('returns a 401 error');
   });
 
-  describe('when the key has exceeded the monthly quota', () => {
-    it.todo('returns a 429 error');
-  });
-
   describe('when the key is active', () => {
     it.todo('increment the key total usage');
   });


### PR DESCRIPTION
Merging this should not break anything

How to test:
- Run `docker compose up`
- Run (make sure to change the `secret` header to same one as the secret in your .env)
```
curl --location 'http://localhost:3002/' \
--header 'secret: 1234' \
--data '{
    "jsonrpc": "2.0",
    "method": "get_keys",
    "params": {
        "app": "snapshot-hub"
    },
    "id": "123456"
}'
```

See the new fields in output
