### PR TITLE
chore: Deprecate unused variables in response

### DIFF
--- a/src/methods.ts
+++ b/src/methods.ts
@@ -101,20 +101,11 @@ export const getKeys = async (app: string) => {
     );
     const result = {
       [app]: {
-        // TODO: `monthly_counts` will be deprecated in the future
-        monthly_counts: activeKeys.reduce((obj, { key, month_total }) => {
-          obj[key] = month_total ?? 0;
-          return obj;
-        }, {}),
         key_counts: activeKeys.reduce((obj, { key, tier, month_total }) => {
           obj[key] = { tier, month: month_total ?? 0 };
           return obj;
         }, {}),
-        limits: {
-          ...limits[app],
-          // TODO: `monthly` will be deprecated in the future
-          monthly: 2e6
-        },
+        limits: limits[app],
         reset
       }
     };

--- a/test/e2e/get_keys.test.ts
+++ b/test/e2e/get_keys.test.ts
@@ -39,7 +39,8 @@ describe('POST / { method: get_keys }', () => {
         tier: 0,
         month: 1
       });
-      expect(response.body.result[apps[0]].limits.monthly).toBe(limits[apps[0]][0].monthly);
+      console.log(response.body.result[apps[0]]);
+      expect(response.body.result[apps[0]].limits[0].monthly).toBe(limits[apps[0]][0].monthly);
       expect(parseInt(response.body.result[apps[0]].reset)).toBeGreaterThan(Date.now() / 1e3);
     });
   });

--- a/test/e2e/get_keys.test.ts
+++ b/test/e2e/get_keys.test.ts
@@ -35,7 +35,6 @@ describe('POST / { method: get_keys }', () => {
         .send({ method: 'get_keys', params: { app: apps[0] } });
 
       expect(response.status).toBe(200);
-      expect(response.body.result[apps[0]].monthly_counts[KEY]).toBe(1);
       expect(response.body.result[apps[0]].key_counts[KEY]).toMatchObject({
         tier: 0,
         month: 1

--- a/test/e2e/get_keys.test.ts
+++ b/test/e2e/get_keys.test.ts
@@ -39,7 +39,6 @@ describe('POST / { method: get_keys }', () => {
         tier: 0,
         month: 1
       });
-      console.log(response.body.result[apps[0]]);
       expect(response.body.result[apps[0]].limits[0].monthly).toBe(limits[apps[0]][0].monthly);
       expect(parseInt(response.body.result[apps[0]].reset)).toBeGreaterThan(Date.now() / 1e3);
     });


### PR DESCRIPTION
We don't need these fields anymore as we updated keycard version on hub and score-api