### PR TITLE
fix: index the active column

### DIFF
--- a/src/helpers/schema.sql
+++ b/src/helpers/schema.sql
@@ -9,6 +9,7 @@ CREATE TABLE `keys` (
   PRIMARY KEY (`owner`),
   INDEX `key` (`key`),
   INDEX owner (owner),
+  INDEX active (active),
   INDEX created (created)
 );
 


### PR DESCRIPTION
Add index on `keys.active` and `reqs_monthly.month` columns, which are used frequently in `WHERE` and `JOIN` in mysql queries