### PR TITLE
feat: generate key on whitelisting the address

### DIFF
--- a/src/methods.ts
+++ b/src/methods.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { getAddress } from '@ethersproject/address';
 import { verifyMessage } from '@ethersproject/wallet';
 import { capture } from '@snapshot-labs/snapshot-sentry';
@@ -127,8 +128,10 @@ export const whitelistAddress = async (params: any) => {
     } catch (e) {
       return { error: 'Invalid address', code: 400 };
     }
-    const success = await createNewKey(address, name);
-    return { success };
+    await createNewKey(address, name);
+    const key = sha256(randomUUID() + address);
+    await updateKey(key, address);
+    return { success: true, key };
   } catch (e: any) {
     if (e.code === 'ER_DUP_ENTRY') return { error: 'Address already whitelisted', code: 409 };
     if (e.code === 'ER_DATA_TOO_LONG') return { error: 'Name too long', code: 400 };


### PR DESCRIPTION
Related to https://github.com/snapshot-labs/workflow/issues/750

### Summery 
- Generate key on whitelisting the address
- Users can still use the signature to generate key on their own


### How to test
- Set a secret in .env (APP_SECRET)
- `docker compose up` 
- call 
```bash
curl --location 'http://localhost:3007' \
--header 'accept: application/json' \
--header 'content-type: application/json' \
--header 'secret: <APP_SECRET>' \
--data '{
    "jsonrpc": "2.0",
    "method": "whitelist",
    "params": {
        "owner": "<OWNER_ADDRESS>",
        "name": "<NAME>"
    },
    "id": "123456789"
}'
```
- It should return `key` now