### PR TITLE
feat: create named API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,18 +111,18 @@ curl --location 'https://keycard.snapshot.org/' \
 
 ### whitelist
 
-This method is used by laser to whitelist new address
+This method whitelists a new address and returns a generated API key. It does
+not require the apps secret, so it can be called directly from the Snapshot UI.
 
 ```sh
 curl --location 'https://keycard.snapshot.org/' \
 --header 'accept: application/json' \
 --header 'content-type: application/json' \
---header 'secret: <APP_SECRET>' \
 --data '{
     "jsonrpc": "2.0",
     "method": "whitelist",
     "params": {
-        "owner": "<OWNER_ADDRESS>",
+        "address": "<OWNER_ADDRESS>",
         "name": "<NAME>"
     },
     "id": "123456789"

--- a/src/helpers/auth.ts
+++ b/src/helpers/auth.ts
@@ -6,7 +6,9 @@ export const authChecker = async (req, res, next) => {
   const { id = null, method } = req.body;
   const { secret = '' } = req.headers;
 
-  if (method !== 'generate_key' && secret !== APPS_SECRET) {
+  const publicMethods = ['generate_key', 'whitelist'];
+
+  if (!publicMethods.includes(method) && secret !== APPS_SECRET) {
     console.log('[Received] method:', method, id);
     return rpcError(res, 401, 'Wrong secret', id);
   }

--- a/test/e2e/whitelist.test.ts
+++ b/test/e2e/whitelist.test.ts
@@ -7,19 +7,32 @@ const ADDRESS = '0x0000000000000000000000000000000000000001';
 
 describe('POST / { method: whitelist }', () => {
   beforeEach(async () => {
-    await cleanupDb();
+    await cleanupDb(NAME);
   });
 
   afterAll(async () => {
-    await cleanupDb();
+    await cleanupDb(NAME);
     return db.endAsync();
   });
 
   describe('on a valid payload', () => {
-    it('whitelists the given address', async () => {
+    it('whitelists the given address and returns a key', async () => {
       const response = await request(HOST)
         .post('/')
         .set({ secret: process.env.SECRET })
+        .send({
+          method: 'whitelist',
+          params: { name: NAME, address: ADDRESS }
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.result.success).toBe(true);
+      expect(response.body.result.key).toHaveLength(64);
+    });
+
+    it('whitelists without the apps secret', async () => {
+      const response = await request(HOST)
+        .post('/')
         .send({
           method: 'whitelist',
           params: { name: NAME, address: ADDRESS }


### PR DESCRIPTION
## Summary
Makes it possible to create a named API key directly from the Snapshot UI (snapshot-labs/sx-monorepo#2111).

The UI's `createApiKey` helper posts `{ method: "whitelist", params: { name, address } }` to keycard with **no `secret` header** and expects `result.key` back. The `whitelist` method already accepts `{ name, address }` and returns a generated `{ key }` (added in #79), but `authChecker` rejected it because only `generate_key` was exempt from the apps secret. This PR adds `whitelist` to the public methods so the browser call reaches the method.

## Changes
- `src/helpers/auth.ts`: allow `whitelist` (alongside `generate_key`) without the apps secret.
- `test/e2e/whitelist.test.ts`: assert the returned key length, add a "no secret" case, and scope `cleanupDb` to this suite's `NAME` so leftover rows no longer leak between tests (this was the source of the flaky 409).
- `README.md`: document `whitelist` as a public, UI-callable method returning a key.

## UI -> keycard contract (from sx-monorepo#2111)
```
POST https://keycard.snapshot.org/
{ "jsonrpc": "2.0", "method": "whitelist", "params": { "name": "<name>", "address": "<wallet>" }, "id": null }
-> { "result": { "success": true, "key": "<64-char key>" } }
```

## Test plan
- `yarn lint` and `yarn typecheck` pass.
- `yarn test:e2e` passes 19/19, stable across 3 runs (incl. the previously flaky `already whitelisted -> 409`).

## For reviewers to decide
1. **Auth model.** This endpoint now whitelists any address with no proof of wallet ownership and no apps secret. `generate_key` proves ownership via a signed message; `whitelist` does not. If we want ownership proof for the UI flow, the UI (sx-monorepo#2111) would need to sign and we'd verify here instead of (or in addition to) opening it up.
2. **One key per owner.** `keys` has `PRIMARY KEY (owner)`, so a second `whitelist` for the same wallet returns `409 Address already whitelisted`. The UI lists multiple keys per wallet (metadata in localStorage), but the backend currently allows only one. Supporting multiple named keys per wallet needs a schema change (surrogate PK) and reworking `updateKey`/`createNewKey` to target a single row; kept out of this PR as it touches the existing `generate_key` flow.

Closes the backend gap for snapshot-labs/sx-monorepo#2111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)