### PR TITLE
fix(test): pass ADDRESS to cleanupDb in whitelist e2e test

### DIFF
--- a/test/e2e/whitelist.test.ts
+++ b/test/e2e/whitelist.test.ts
@@ -7,11 +7,11 @@ const ADDRESS = '0x0000000000000000000000000000000000000001';
 
 describe('POST / { method: whitelist }', () => {
   beforeEach(async () => {
-    await cleanupDb();
+    await cleanupDb(ADDRESS);
   });
 
   afterAll(async () => {
-    await cleanupDb();
+    await cleanupDb(ADDRESS);
     return db.endAsync();
   });
 


### PR DESCRIPTION
## What

`whitelist.test.ts`'s `beforeEach` / `afterAll` call `cleanupDb()` with no argument. That only deletes rows where `key`/`name`/`owner` are empty or NULL — leaving rows inserted by prior tests in the table. The `'returns a 409 error'` test then hits a duplicate-key violation on its setup INSERT, before reaching the actual HTTP assertion.

Switching to `cleanupDb(ADDRESS)` matches the pattern already used in `generate_key.test.ts`, where ADDRESS-keyed cleanup deletes rows by `owner = ?` (and `key IS NULL`).

## Why this surfaced now

Test passed on master under Node 18 but began failing intermittently on the Node 22 PR (#85) — likely due to V8 microtask scheduling differences exposing the latent test-isolation bug. The bug is pre-existing; Node 22 just made it consistent.

## Test

`yarn test` — the `'returns a 409 error'` test should now reach the actual HTTP assertion and pass.