### PR TITLE
feat: add get_keys_by_owner read method

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 DATABASE_URL=mysql://root:root@mysql:3306/keycard
 SECRET=
+HUB_URL=https://hub.snapshot.org/graphql
 # Sentry (optional)
 SENTRY_DSN=

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ curl --location 'https://keycard.snapshot.org/' \
 
 ### get_keys_by_owner
 
-Returns the caller's own keys, including the key values.
+Returns the caller's own active keys, including the key values.
 
 Authenticated with an EIP-712 signature from the owner's Snapshot alias, so no
 wallet prompt is needed once an alias is registered:
@@ -121,7 +121,7 @@ wallet prompt is needed once an alias is registered:
 - Domain: `{ "name": "snapshot", "version": "0.1.4" }`
 - Type: `GetKeys { from: address, alias: address, timestamp: uint64 }`
 - `from` is the owner address, `alias` is the signing alias address, and
-  `timestamp` is unix seconds.
+  `timestamp` is unix seconds, within 5 minutes of server time.
 - The signing alias must be registered for `from` on the hub, and less than 90 days old (same window the sequencer applies).
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Authenticated with an EIP-712 signature from the owner's Snapshot alias, so no
 wallet prompt is needed once an alias is registered:
 
 - Domain: `{ "name": "snapshot", "version": "0.1.4" }`
-- Type: `GetKeys { from: string, alias: address, timestamp: uint64 }`
+- Type: `GetKeys { from: address, alias: address, timestamp: uint64 }`
 - `from` is the owner address, `alias` is the signing alias address, and
   `timestamp` is unix seconds.
 - The signing alias must be registered for `from` on the hub, and less than 90 days old (same window the sequencer applies).

--- a/README.md
+++ b/README.md
@@ -111,6 +111,36 @@ curl --location 'https://keycard.snapshot.org/' \
 }'
 ```
 
+### get_keys_by_owner
+
+Returns the caller's own keys, including the key values.
+
+Authenticated with an EIP-712 signature from the owner's Snapshot alias, so no
+wallet prompt is needed once an alias is registered:
+
+- Domain: `{ "name": "snapshot", "version": "0.1.4" }`
+- Type: `GetKeys { from: string, alias: address, timestamp: uint64 }`
+- `from` is the owner address, `alias` is the signing alias address, and
+  `timestamp` is unix seconds.
+- The signing alias must be registered for `from` on the hub, and less than 90 days old (same window the sequencer applies).
+
+```sh
+curl --location 'https://keycard.snapshot.org/' \
+--header 'accept: application/json' \
+--header 'content-type: application/json' \
+--data '{
+    "jsonrpc": "2.0",
+    "method": "get_keys_by_owner",
+    "params": {
+        "from": "<OWNER_ADDRESS>",
+        "alias": "<ALIAS_ADDRESS>",
+        "timestamp": 1769123456,
+        "sig": "<SIGNATURE>"
+    },
+    "id": "123456789"
+}'
+```
+
 ### whitelist
 
 This method is used by laser to whitelist new address

--- a/src/helpers/aliases.ts
+++ b/src/helpers/aliases.ts
@@ -1,0 +1,40 @@
+const HUB_URL = process.env.HUB_URL || 'https://hub.snapshot.org/graphql';
+
+const HUB_TIMEOUT_MS = 3e3;
+// Must match the sequencer's DEFAULT_ALIAS_EXPIRY_DAYS (helpers/alias.ts). also same as UI
+const ALIAS_EXPIRY_DAYS = 90;
+
+const ALIASES_QUERY = `
+  query Aliases($address: String!, $alias: String!, $created_gt: Int) {
+    aliases(
+      where: { address: $address, alias: $alias, created_gt: $created_gt }
+    ) {
+      address
+      alias
+    }
+  }`;
+
+export async function isAliasOf(
+  address: string,
+  alias: string
+): Promise<boolean> {
+  const createdGt =
+    Math.floor(Date.now() / 1e3) - ALIAS_EXPIRY_DAYS * 24 * 60 * 60;
+
+  const res = await fetch(HUB_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      query: ALIASES_QUERY,
+      variables: { address, alias, created_gt: createdGt }
+    }),
+    signal: AbortSignal.timeout(HUB_TIMEOUT_MS)
+  });
+  if (!res.ok) throw new Error(`Hub responded with ${res.status}`);
+
+  const body = await res.json();
+  if (body.errors)
+    throw new Error(body.errors[0]?.message || 'Hub returned GraphQL errors');
+
+  return (body?.data?.aliases?.length ?? 0) > 0;
+}

--- a/src/helpers/aliases.ts
+++ b/src/helpers/aliases.ts
@@ -33,9 +33,9 @@ export async function isAliasOf(
   if (!res.ok) throw new Error(`Hub responded with ${res.status}`);
 
   const body = await res.json();
-  if (!body.data) throw new Error('Hub returned no data');
   if (body.errors)
     throw new Error(body.errors[0]?.message || 'Hub returned GraphQL errors');
+  if (!body.data) throw new Error('Hub returned no data');
 
   return (body.data.aliases?.length ?? 0) > 0;
 }

--- a/src/helpers/aliases.ts
+++ b/src/helpers/aliases.ts
@@ -33,8 +33,9 @@ export async function isAliasOf(
   if (!res.ok) throw new Error(`Hub responded with ${res.status}`);
 
   const body = await res.json();
+  if (!body.data) throw new Error('Hub returned no data');
   if (body.errors)
     throw new Error(body.errors[0]?.message || 'Hub returned GraphQL errors');
 
-  return (body?.data?.aliases?.length ?? 0) > 0;
+  return (body.data.aliases?.length ?? 0) > 0;
 }

--- a/src/helpers/auth.ts
+++ b/src/helpers/auth.ts
@@ -2,11 +2,13 @@ import { rpcError } from './utils';
 
 const APPS_SECRET = process.env.SECRET || '';
 
+const PUBLIC_METHODS = ['generate_key', 'get_keys_by_owner'];
+
 export const authChecker = async (req, res, next) => {
   const { id = null, method } = req.body;
   const { secret = '' } = req.headers;
 
-  if (method !== 'generate_key' && secret !== APPS_SECRET) {
+  if (!PUBLIC_METHODS.includes(method) && secret !== APPS_SECRET) {
     console.log('[Received] method:', method, id);
     return rpcError(res, 401, 'Wrong secret', id);
   }

--- a/src/helpers/eip712.ts
+++ b/src/helpers/eip712.ts
@@ -1,0 +1,18 @@
+import { verifyTypedData } from '@ethersproject/wallet';
+
+const DOMAIN = { name: 'snapshot', version: '0.1.4' };
+
+const GET_KEYS_TYPES = {
+  GetKeys: [
+    { name: 'from', type: 'string' },
+    { name: 'alias', type: 'address' },
+    { name: 'timestamp', type: 'uint64' }
+  ]
+};
+
+export function recoverGetKeysSigner(
+  message: { from: string; alias: string; timestamp: number },
+  sig: string
+): string {
+  return verifyTypedData(DOMAIN, GET_KEYS_TYPES, message, sig);
+}

--- a/src/helpers/eip712.ts
+++ b/src/helpers/eip712.ts
@@ -4,7 +4,7 @@ const DOMAIN = { name: 'snapshot', version: '0.1.4' };
 
 const GET_KEYS_TYPES = {
   GetKeys: [
-    { name: 'from', type: 'string' },
+    { name: 'from', type: 'address' },
     { name: 'alias', type: 'address' },
     { name: 'timestamp', type: 'uint64' }
   ]

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -73,7 +73,7 @@ export const generateKey = async (params: any) => {
     await updateKey(key, signer);
     return { key };
   } catch (err) {
-    capture(err, { context: { params } });
+    capture(err);
     return { error: 'Error while generating key', code: 500 };
   }
 };
@@ -127,7 +127,7 @@ export const getKeys = async (app: string) => {
 
 export const getKeysByOwner = async (params: any) => {
   try {
-    const { from, alias, timestamp, sig } = params;
+    const { from, alias, timestamp, sig } = params ?? {};
 
     let owner: string;
     try {
@@ -136,7 +136,10 @@ export const getKeysByOwner = async (params: any) => {
       return { error: 'Invalid address', code: 400 };
     }
 
-    const ts = Date.now() / 1e3;
+    if (!Number.isFinite(timestamp))
+      return { error: 'Invalid timestamp', code: 400 };
+
+    const ts = Math.floor(Date.now() / 1e3);
     if (timestamp > ts + SIGNATURE_WINDOW || timestamp < ts - SIGNATURE_WINDOW)
       return { error: 'Signature expired', code: 401 };
 
@@ -166,7 +169,7 @@ export const getKeysByOwner = async (params: any) => {
       }))
     };
   } catch (err) {
-    capture(err, { context: { params } });
+    capture(err, { context: { from: params?.from, alias: params?.alias } });
     return { error: 'Error while getting keys', code: 500 };
   }
 };

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -22,6 +22,13 @@ type Key = {
   month_total: number;
 };
 
+type GetKeysByOwnerParams = {
+  from: string;
+  alias: string;
+  timestamp: number;
+  sig: string;
+};
+
 const getKey = async (key: string, app: string): Promise<Key | null> => {
   const [keyData] = await db.queryAsync(
     `
@@ -125,7 +132,7 @@ export const getKeys = async (app: string) => {
   }
 };
 
-export const getKeysByOwner = async (params: any) => {
+export const getKeysByOwner = async (params: GetKeysByOwnerParams) => {
   try {
     const { from, alias, timestamp, sig } = params ?? {};
 

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -150,7 +150,7 @@ export const getKeysByOwner = async (params: any) => {
     const rows = await db.queryAsync(
       `
         SELECT \`key\`, owner, name, tier, created, updated, active
-        FROM \`keys\` WHERE owner = ? AND active = 1`,
+        FROM \`keys\` WHERE owner = ? AND active = 1 AND \`key\` IS NOT NULL`,
       [owner]
     );
     if (!rows.length) return { keys: [] };

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -10,6 +10,7 @@ import { sha256 } from './utils';
 import { createNewKey, updateKey, updateTotal } from './writer';
 
 const apps = Object.keys(limits);
+const SIGNATURE_WINDOW = 300; // 5 minutes before or after the server time
 
 type Key = {
   key: string;
@@ -135,6 +136,10 @@ export const getKeysByOwner = async (params: any) => {
       return { error: 'Invalid address', code: 400 };
     }
 
+    const ts = Date.now() / 1e3;
+    if (timestamp > ts + SIGNATURE_WINDOW || timestamp < ts - SIGNATURE_WINDOW)
+      return { error: 'Signature expired', code: 401 };
+
     let signer: string;
     try {
       signer = recoverGetKeysSigner({ from, alias, timestamp }, sig);
@@ -149,30 +154,16 @@ export const getKeysByOwner = async (params: any) => {
 
     const rows = await db.queryAsync(
       `
-        SELECT \`key\`, owner, name, tier, created, updated, active
+        SELECT \`key\`, name, created
         FROM \`keys\` WHERE owner = ? AND active = 1 AND \`key\` IS NOT NULL`,
       [owner]
     );
-    if (!rows.length) return { keys: [] };
-
-    const keyHashes = rows.map(row => row.key).filter(Boolean);
-    const usageRows = keyHashes.length
-      ? await db.queryAsync(
-          `
-        SELECT \`key\`, app, total FROM reqs_monthly
-        WHERE \`key\` IN (?)
-          AND month = DATE_FORMAT(CURRENT_TIMESTAMP, '%m-%Y')`,
-          [keyHashes]
-        )
-      : [];
-    const usageByKey: Record<string, { app: string; total: number }[]> =
-      usageRows.reduce((acc, { key, app, total }) => {
-        (acc[key] ??= []).push({ app, total });
-        return acc;
-      }, {});
-
     return {
-      keys: rows.map(row => ({ ...row, usage: usageByKey[row.key] ?? [] }))
+      keys: rows.map(row => ({
+        key: row.key,
+        name: row.name,
+        created: row.created
+      }))
     };
   } catch (err) {
     capture(err, { context: { params } });

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -3,6 +3,8 @@ import { getAddress } from '@ethersproject/address';
 import { verifyMessage } from '@ethersproject/wallet';
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import { limits } from './config.json';
+import { isAliasOf } from './helpers/aliases';
+import { recoverGetKeysSigner } from './helpers/eip712';
 import db from './helpers/mysql';
 import { sha256 } from './utils';
 import { createNewKey, updateKey, updateTotal } from './writer';
@@ -63,7 +65,7 @@ export const generateKey = async (params: any) => {
     } catch {
       return { error: 'Invalid signature', code: 400 };
     }
-    console.log('Generate key request from', signer, 'with sig', params.sig);
+    console.log('Generate key request from', signer);
     const whitelisted = await isWhitelist(signer);
     if (!whitelisted) return { error: 'Not whitelisted', code: 401 };
     const key = sha256(params.sig + signer);
@@ -124,18 +126,32 @@ export const getKeys = async (app: string) => {
 
 export const getKeysByOwner = async (params: any) => {
   try {
-    let { address } = params;
+    const { from, alias, timestamp, sig } = params;
+
+    let owner: string;
     try {
-      address = getAddress(address);
+      owner = getAddress(from);
     } catch {
       return { error: 'Invalid address', code: 400 };
     }
+
+    let signer: string;
+    try {
+      signer = recoverGetKeysSigner({ from, alias, timestamp }, sig);
+    } catch {
+      return { error: 'Invalid signature', code: 400 };
+    }
+
+    if (signer !== getAddress(alias))
+      return { error: 'Invalid signature', code: 400 };
+    if (!(await isAliasOf(owner, signer)))
+      return { error: 'Alias not authorized', code: 401 };
 
     const rows = await db.queryAsync(
       `
         SELECT \`key\`, owner, name, tier, created, updated, active
         FROM \`keys\` WHERE owner = ? AND active = 1`,
-      [address]
+      [owner]
     );
     if (!rows.length) return { keys: [] };
 
@@ -156,10 +172,7 @@ export const getKeysByOwner = async (params: any) => {
       }, {});
 
     return {
-      keys: rows.map(({ key, ...rest }) => ({
-        ...rest,
-        usage: usageByKey[key] ?? []
-      }))
+      keys: rows.map(row => ({ ...row, usage: usageByKey[row.key] ?? [] }))
     };
   } catch (err) {
     capture(err, { context: { params } });

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -122,6 +122,51 @@ export const getKeys = async (app: string) => {
   }
 };
 
+export const getKeysByOwner = async (params: any) => {
+  try {
+    let { address } = params;
+    try {
+      address = getAddress(address);
+    } catch {
+      return { error: 'Invalid address', code: 400 };
+    }
+
+    const rows = await db.queryAsync(
+      `
+        SELECT \`key\`, owner, name, tier, created, updated, active
+        FROM \`keys\` WHERE owner = ? AND active = 1`,
+      [address]
+    );
+    if (!rows.length) return { keys: [] };
+
+    const keyHashes = rows.map(row => row.key).filter(Boolean);
+    const usageRows = keyHashes.length
+      ? await db.queryAsync(
+          `
+        SELECT \`key\`, app, total FROM reqs_monthly
+        WHERE \`key\` IN (?)
+          AND month = DATE_FORMAT(CURRENT_TIMESTAMP, '%m-%Y')`,
+          [keyHashes]
+        )
+      : [];
+    const usageByKey: Record<string, { app: string; total: number }[]> =
+      usageRows.reduce((acc, { key, app, total }) => {
+        (acc[key] ??= []).push({ app, total });
+        return acc;
+      }, {});
+
+    return {
+      keys: rows.map(({ key, ...rest }) => ({
+        ...rest,
+        usage: usageByKey[key] ?? []
+      }))
+    };
+  } catch (err) {
+    capture(err, { context: { params } });
+    return { error: 'Error while getting keys', code: 500 };
+  }
+};
+
 export const whitelistAddress = async (params: any) => {
   try {
     const { name } = params;

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -1,12 +1,18 @@
 import { capture } from '@snapshot-labs/snapshot-sentry';
 import express from 'express';
-import { authChecker } from './helpers/auth';
-import { rpcError, rpcSuccess } from './helpers/utils';
-import { generateKey, getKeys, logReq, whitelistAddress } from './methods';
 import {
   name as packageName,
   version as packageVersion
 } from '../package.json';
+import { authChecker } from './helpers/auth';
+import { rpcError, rpcSuccess } from './helpers/utils';
+import {
+  generateKey,
+  getKeys,
+  getKeysByOwner,
+  logReq,
+  whitelistAddress
+} from './methods';
 
 const router = express.Router();
 
@@ -28,6 +34,8 @@ router.post('/', authChecker, async (req, res) => {
     let result: any = {};
     if (method === 'log_req') result = await logReq(params.key, params.app);
     else if (method === 'get_keys') result = await getKeys(params.app);
+    else if (method === 'get_keys_by_owner')
+      result = await getKeysByOwner(params);
     else if (method === 'generate_key') result = await generateKey(params);
     else if (method === 'whitelist') result = await whitelistAddress(params);
     else return rpcError(res, 400, 'invalid method', id);

--- a/test/.env.test
+++ b/test/.env.test
@@ -1,3 +1,4 @@
 DATABASE_URL=mysql://root:root@localhost:3306/keycard_test
 SECRET=000
+HUB_URL=http://localhost:3078/graphql
 NODE_ENV=test

--- a/test/e2e/get_keys_by_owner.test.ts
+++ b/test/e2e/get_keys_by_owner.test.ts
@@ -17,7 +17,7 @@ const GetKeysSchema = {
 
 const OWNER = '0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6';
 
-const registered = new Set<string>();
+const registered = new Map<string, number>();
 let hubMode: 'ok' | 'graphql-error' | 'http-error' = 'ok';
 let hub: http.Server;
 
@@ -33,8 +33,12 @@ async function signedParams(
   return { ...message, sig };
 }
 
-function registerAlias(address: string, alias: string) {
-  registered.add(`${address}:${alias}`.toLowerCase());
+function registerAlias(
+  address: string,
+  alias: string,
+  created = Math.floor(Date.now() / 1e3)
+) {
+  registered.set(`${address}:${alias}`.toLowerCase(), created);
 }
 
 describe('POST / { method: get_keys_by_owner }', () => {
@@ -56,10 +60,12 @@ describe('POST / { method: get_keys_by_owner }', () => {
             );
           }
 
-          const { address, alias } = JSON.parse(body).variables;
-          const aliases = registered.has(`${address}:${alias}`.toLowerCase())
-            ? [{ address, alias }]
-            : [];
+          const { address, alias, created_gt } = JSON.parse(body).variables;
+          const created = registered.get(`${address}:${alias}`.toLowerCase());
+          const aliases =
+            created !== undefined && created > created_gt
+              ? [{ address, alias }]
+              : [];
           res.end(JSON.stringify({ data: { aliases } }));
         });
       })
@@ -113,6 +119,57 @@ describe('POST / { method: get_keys_by_owner }', () => {
 
       expect(response.status).toBe(200);
       expect(response.body.result.keys).toEqual([]);
+    });
+  });
+
+  describe('when the alias is registered but expired', () => {
+    it('returns a 401 error', async () => {
+      const wallet = Wallet.createRandom();
+      const created = Math.floor(Date.now() / 1e3) - 91 * 24 * 60 * 60;
+      registerAlias(OWNER, wallet.address, created);
+
+      const response = await request(HOST)
+        .post('/')
+        .send({
+          method: 'get_keys_by_owner',
+          params: await signedParams(wallet, OWNER)
+        });
+
+      expect(response.status).toBe(401);
+      expect(response.body.error.data).toContain('Alias not authorized');
+    });
+  });
+
+  describe('when the timestamp is not a number', () => {
+    it('returns a 400 error', async () => {
+      const wallet = Wallet.createRandom();
+      registerAlias(OWNER, wallet.address);
+
+      const response = await request(HOST)
+        .post('/')
+        .send({
+          method: 'get_keys_by_owner',
+          params: {
+            from: OWNER,
+            alias: wallet.address,
+            timestamp: 'now',
+            sig: '0x00'
+          }
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error.data).toContain('Invalid timestamp');
+    });
+  });
+
+  describe('when params is null', () => {
+    it('returns a 400 error', async () => {
+      const response = await request(HOST)
+        .post('/')
+        .send({ method: 'get_keys_by_owner', params: null });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error.data).toContain('Invalid address');
     });
   });
 

--- a/test/e2e/get_keys_by_owner.test.ts
+++ b/test/e2e/get_keys_by_owner.test.ts
@@ -9,7 +9,7 @@ const DOMAIN = { name: 'snapshot', version: '0.1.4' };
 
 const GetKeysSchema = {
   GetKeys: [
-    { name: 'from', type: 'string' },
+    { name: 'from', type: 'address' },
     { name: 'alias', type: 'address' },
     { name: 'timestamp', type: 'uint64' }
   ]
@@ -168,13 +168,16 @@ describe('POST / { method: get_keys_by_owner }', () => {
 
   describe('when the address is not valid', () => {
     it('returns a 400 error', async () => {
-      const wallet = Wallet.createRandom();
-
       const response = await request(HOST)
         .post('/')
         .send({
           method: 'get_keys_by_owner',
-          params: await signedParams(wallet, 'test')
+          params: {
+            from: 'test',
+            alias: Wallet.createRandom().address,
+            timestamp: Math.floor(Date.now() / 1e3),
+            sig: '0x00'
+          }
         });
 
       expect(response.status).toBe(400);

--- a/test/e2e/get_keys_by_owner.test.ts
+++ b/test/e2e/get_keys_by_owner.test.ts
@@ -1,0 +1,216 @@
+import http from 'http';
+import { Wallet } from '@ethersproject/wallet';
+import request from 'supertest';
+import db from '../../src/helpers/mysql';
+import { whitelistAddress } from '../../src/methods';
+import { cleanupDb, HOST } from '../utils';
+
+const DOMAIN = { name: 'snapshot', version: '0.1.4' };
+
+const GetKeysSchema = {
+  GetKeys: [
+    { name: 'from', type: 'string' },
+    { name: 'alias', type: 'address' },
+    { name: 'timestamp', type: 'uint64' }
+  ]
+};
+
+const OWNER = '0x220bc93D88C0aF11f1159eA89a885d5ADd3A7Cf6';
+
+const registered = new Set<string>();
+let hubMode: 'ok' | 'graphql-error' | 'http-error' = 'ok';
+let hub: http.Server;
+
+async function signedParams(
+  wallet: Wallet,
+  from: string,
+  alias = wallet.address
+) {
+  const message = { from, alias, timestamp: Math.floor(Date.now() / 1e3) };
+  const sig = await wallet._signTypedData(DOMAIN, GetKeysSchema, message);
+
+  return { ...message, sig };
+}
+
+function registerAlias(address: string, alias: string) {
+  registered.add(`${address}:${alias}`.toLowerCase());
+}
+
+describe('POST / { method: get_keys_by_owner }', () => {
+  beforeAll(done => {
+    hub = http
+      .createServer((req, res) => {
+        let body = '';
+        req.on('data', chunk => (body += chunk));
+        req.on('end', () => {
+          if (hubMode === 'http-error') {
+            res.writeHead(500);
+            return res.end();
+          }
+
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          if (hubMode === 'graphql-error') {
+            return res.end(
+              JSON.stringify({ errors: [{ message: 'rate limited' }] })
+            );
+          }
+
+          const { address, alias } = JSON.parse(body).variables;
+          const aliases = registered.has(`${address}:${alias}`.toLowerCase())
+            ? [{ address, alias }]
+            : [];
+          res.end(JSON.stringify({ data: { aliases } }));
+        });
+      })
+      .listen(3078, done);
+  });
+
+  beforeEach(async () => {
+    hubMode = 'ok';
+    registered.clear();
+    await cleanupDb(OWNER);
+  });
+
+  afterAll(async () => {
+    await cleanupDb(OWNER);
+    hub.close();
+    return db.endAsync();
+  });
+
+  describe('when the alias is registered for the owner', () => {
+    it('returns the keys including the key value', async () => {
+      const { key } = await whitelistAddress({
+        name: 'test key',
+        address: OWNER
+      });
+      const wallet = Wallet.createRandom();
+      registerAlias(OWNER, wallet.address);
+
+      const response = await request(HOST)
+        .post('/')
+        .send({
+          method: 'get_keys_by_owner',
+          params: await signedParams(wallet, OWNER)
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.result.keys).toHaveLength(1);
+      expect(response.body.result.keys[0].key).toBe(key);
+      expect(response.body.result.keys[0].name).toBe('test key');
+    });
+
+    it('returns an empty list when the owner has no keys', async () => {
+      const wallet = Wallet.createRandom();
+      registerAlias(OWNER, wallet.address);
+
+      const response = await request(HOST)
+        .post('/')
+        .send({
+          method: 'get_keys_by_owner',
+          params: await signedParams(wallet, OWNER)
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.result.keys).toEqual([]);
+    });
+  });
+
+  describe('when the alias is not registered for the owner', () => {
+    it('returns a 401 error', async () => {
+      const wallet = Wallet.createRandom();
+
+      const response = await request(HOST)
+        .post('/')
+        .send({
+          method: 'get_keys_by_owner',
+          params: await signedParams(wallet, OWNER)
+        });
+
+      expect(response.status).toBe(401);
+      expect(response.body.error.data).toContain('Alias not authorized');
+    });
+  });
+
+  describe('when the signature is not valid', () => {
+    it('returns a 400 error', async () => {
+      const wallet = Wallet.createRandom();
+
+      const response = await request(HOST)
+        .post('/')
+        .send({
+          method: 'get_keys_by_owner',
+          params: {
+            ...(await signedParams(wallet, OWNER)),
+            sig: 'test'
+          }
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error.data).toContain('Invalid signature');
+    });
+
+    it('returns a 400 error when signed by another alias', async () => {
+      const wallet = Wallet.createRandom();
+      const otherAlias = Wallet.createRandom().address;
+      registerAlias(OWNER, otherAlias);
+
+      const response = await request(HOST)
+        .post('/')
+        .send({
+          method: 'get_keys_by_owner',
+          params: await signedParams(wallet, OWNER, otherAlias)
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error.data).toContain('Invalid signature');
+    });
+  });
+
+  describe('when the address is not valid', () => {
+    it('returns a 400 error', async () => {
+      const wallet = Wallet.createRandom();
+
+      const response = await request(HOST)
+        .post('/')
+        .send({
+          method: 'get_keys_by_owner',
+          params: await signedParams(wallet, 'test')
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error.data).toContain('Invalid address');
+    });
+  });
+
+  describe('when the hub is not available', () => {
+    it('returns a 500 error on hub failure', async () => {
+      hubMode = 'http-error';
+      const wallet = Wallet.createRandom();
+      registerAlias(OWNER, wallet.address);
+
+      const response = await request(HOST)
+        .post('/')
+        .send({
+          method: 'get_keys_by_owner',
+          params: await signedParams(wallet, OWNER)
+        });
+
+      expect(response.status).toBe(500);
+    });
+
+    it('returns a 500 error on hub graphql errors', async () => {
+      hubMode = 'graphql-error';
+      const wallet = Wallet.createRandom();
+      registerAlias(OWNER, wallet.address);
+
+      const response = await request(HOST)
+        .post('/')
+        .send({
+          method: 'get_keys_by_owner',
+          params: await signedParams(wallet, OWNER)
+        });
+
+      expect(response.status).toBe(500);
+    });
+  });
+});

--- a/test/e2e/get_keys_by_owner.test.ts
+++ b/test/e2e/get_keys_by_owner.test.ts
@@ -24,9 +24,10 @@ let hub: http.Server;
 async function signedParams(
   wallet: Wallet,
   from: string,
-  alias = wallet.address
+  alias = wallet.address,
+  timestamp = Math.floor(Date.now() / 1e3)
 ) {
-  const message = { from, alias, timestamp: Math.floor(Date.now() / 1e3) };
+  const message = { from, alias, timestamp };
   const sig = await wallet._signTypedData(DOMAIN, GetKeysSchema, message);
 
   return { ...message, sig };
@@ -163,6 +164,40 @@ describe('POST / { method: get_keys_by_owner }', () => {
 
       expect(response.status).toBe(400);
       expect(response.body.error.data).toContain('Invalid signature');
+    });
+  });
+
+  describe('when the signature is expired', () => {
+    it('returns a 401 error on a stale timestamp', async () => {
+      const wallet = Wallet.createRandom();
+      registerAlias(OWNER, wallet.address);
+      const timestamp = Math.floor(Date.now() / 1e3) - 600;
+
+      const response = await request(HOST)
+        .post('/')
+        .send({
+          method: 'get_keys_by_owner',
+          params: await signedParams(wallet, OWNER, wallet.address, timestamp)
+        });
+
+      expect(response.status).toBe(401);
+      expect(response.body.error.data).toContain('Signature expired');
+    });
+
+    it('returns a 401 error on a future timestamp', async () => {
+      const wallet = Wallet.createRandom();
+      registerAlias(OWNER, wallet.address);
+      const timestamp = Math.floor(Date.now() / 1e3) + 600;
+
+      const response = await request(HOST)
+        .post('/')
+        .send({
+          method: 'get_keys_by_owner',
+          params: await signedParams(wallet, OWNER, wallet.address, timestamp)
+        });
+
+      expect(response.status).toBe(401);
+      expect(response.body.error.data).toContain('Signature expired');
     });
   });
 


### PR DESCRIPTION
## Summary

Adds `get_keys_by_owner`: a public JSON-RPC method that lets users fetch their own API keys, authenticated with their Snapshot alias — the same signing flow the sequencer accepts for follow and vote, so the UI needs no wallet popup once an alias exists.

- Request `{ from, alias, timestamp, sig }` where `sig` is an EIP-712 `GetKeys` signature made by the alias (domain `snapshot 0.1.4`)
- The server recovers the signer, checks it matches `alias`, then confirms on the hub that the alias is registered for `from` and less than 90 days old (same window the sequencer applies)
- Returns the owner's active keys **including the key value** — the read is now owner-only, so the earlier reason to strip it is gone
- Errors: 400 invalid address or signature, 401 alias not registered, 500 hub unreachable
- e2e suite runs against a stub hub started inside the test, so CI has no network dependency
- `generate_key` no longer logs the signature (the key is derived from it)

## How to test

Easiest through the UI: snapshot-labs/sx-monorepo#2247 has step-by-step instructions — run this branch locally and drive it from the settings page.

Or directly: see `get_keys_by_owner` in the README for the message shape and a curl example; sign with any registered alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
