### PR TITLE
chore(ci): flatten single-target matrix in workflows

### DIFF
--- a/.github/workflows/create-sentry-release.yaml
+++ b/.github/workflows/create-sentry-release.yaml
@@ -7,11 +7,8 @@ on:
 
 jobs:
   create-sentry-release:
-    strategy:
-      matrix:
-        target: ['22']
     uses: snapshot-labs/actions/.github/workflows/create-sentry-release.yml@main
     secrets: inherit
     with:
       project: keycard
-      target: ${{ matrix.target }}
+      target: '22'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,10 +7,7 @@ on:
 
 jobs:
   lint:
-    strategy:
-      matrix:
-        target: ['22']
     uses: snapshot-labs/actions/.github/workflows/lint.yml@main
     with:
-      target: ${{ matrix.target }}
+      target: '22'
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,8 @@ on:
 
 jobs:
   test:
-    strategy:
-      matrix:
-        target: ['22']
     uses: snapshot-labs/actions/.github/workflows/test.yml@main
     secrets: inherit
     with:
-      target: ${{ matrix.target }}
+      target: '22'
       mysql_database_name: keycard_test


### PR DESCRIPTION
Pulled out of #95: the three workflows run a one-element matrix (`target: ['22']`), which just adds noise — the reusable actions take the target directly.

No behavior change: same Node version, same jobs. `test.yml` stays on MySQL; only the matrix wrapper is removed (the PostgreSQL switch remains in #95).

## How to test

CI on this PR — same lint/test jobs, now named without the matrix suffix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)